### PR TITLE
Add lendable lock support to FixedReentrantReadWriteLock

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,6 +1,6 @@
 name            = Utility Library
 description     = A common module for utility
-version         = 5.0.0
+version         = 5.1.0
 
 url             = https://github.com/Akazukin-Team/Utility-Library
 

--- a/util/src/main/java/org/akazukin/util/concurrent/FixedReentrantReadWriteLock.java
+++ b/util/src/main/java/org/akazukin/util/concurrent/FixedReentrantReadWriteLock.java
@@ -2,11 +2,14 @@ package org.akazukin.util.concurrent;
 
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.experimental.FieldDefaults;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -34,6 +37,18 @@ public class FixedReentrantReadWriteLock {
             final Lock lock = new Lock(this, req);
             this.locks.add(lock);
             this.lockRequests.remove(req);
+
+            if (!shared) {
+                final Collection<Lock> toBorrow = new HashSet<>();
+                for (final Lock existingLock : this.locks) {
+                    if (existingLock != lock && existingLock.isShared() && existingLock.isLendable()) {
+                        lock.addLend(existingLock);
+                        toBorrow.add(existingLock);
+                    }
+                }
+                this.locks.removeAll(toBorrow);
+            }
+
             return lock;
         } catch (final InterruptedException e) {
             throw new RuntimeException(e);
@@ -63,7 +78,17 @@ public class FixedReentrantReadWriteLock {
         } else {
             final boolean hasSelfLock = this.locks.stream()
                     .anyMatch(lock -> lock.getOwner() == req.getOwner());
-            return hasSelfLock || this.locks.isEmpty();
+            if (hasSelfLock) {
+                return true;
+            }
+            if (!this.locks.isEmpty()) {
+                for (final Lock lock : this.locks) {
+                    if (!lock.isShared() || !lock.isLendable()) {
+                        return false;
+                    }
+                }
+            }
+            return true;
         }
     }
 
@@ -93,10 +118,15 @@ public class FixedReentrantReadWriteLock {
         return this.locks.size();
     }
 
-    public void unlock(final ILock lock) {
+    public void unlock(final ILock ilock) {
         this.mutex.lock();
         try {
-            this.locks.remove(lock);
+            this.locks.remove(ilock);
+            if (ilock instanceof Lock) {
+                final Lock lock = (Lock) ilock;
+                final Lock[] lentLocks = lock.clearLends();
+                Collections.addAll(this.locks, lentLocks);
+            }
             this.condition.signalAll();
         } finally {
             this.mutex.unlock();
@@ -110,6 +140,8 @@ public class FixedReentrantReadWriteLock {
     public interface ILock extends AutoCloseable {
         @Override
         void close();
+
+        void setLendable(boolean lendable);
     }
 
     @Getter
@@ -124,14 +156,35 @@ public class FixedReentrantReadWriteLock {
         }
     }
 
-    @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
-    private static class Lock implements ILock {
-        FixedReentrantReadWriteLock lock;
-        LockRequest request;
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    static class Lock implements ILock {
+        private static final Lock[] EMPTY_ARR = new Lock[0];
+
+        final FixedReentrantReadWriteLock lock;
+        final LockRequest request;
+        final Set<Lock> lends = new HashSet<>();
+        @Getter
+        @Setter
+        boolean lendable;
 
         public Lock(final FixedReentrantReadWriteLock lock, final LockRequest request) {
             this.lock = lock;
             this.request = request;
+        }
+
+        public synchronized void addLend(final Lock lock) {
+            this.lends.add(lock);
+        }
+
+        public synchronized void setLends(final Lock lock) {
+            this.lends.clear();
+            this.lends.add(lock);
+        }
+
+        public synchronized Lock[] clearLends() {
+            final Lock[] res = this.lends.toArray(EMPTY_ARR);
+            this.lends.clear();
+            return res;
         }
 
         public Thread getOwner() {
@@ -146,5 +199,6 @@ public class FixedReentrantReadWriteLock {
         public void close() {
             this.lock.unlock(this);
         }
+
     }
 }

--- a/util/src/unitTest/java/org/akazukin/util/concurrent/FixedReentrantReadWriteLockTest.java
+++ b/util/src/unitTest/java/org/akazukin/util/concurrent/FixedReentrantReadWriteLockTest.java
@@ -217,4 +217,193 @@ public class FixedReentrantReadWriteLockTest {
         assertTrue(fut.get(1, TimeUnit.SECONDS));
         assertEquals(0, locker.getLockCount());
     }
+
+    @Test
+    public void lend_single_shared_lock_to_exclusive() throws Exception {
+        final FixedReentrantReadWriteLock locker = new FixedReentrantReadWriteLock();
+
+        // Thread 1: acquire shared lock and set lendable
+        final CompletableFuture<Boolean> sharedFuture = CompletableFuture.supplyAsync(() -> {
+            try (final FixedReentrantReadWriteLock.ILock lock = locker.sharedLock()) {
+                assertEquals(1, locker.getLockCount());
+                assertEquals(FixedReentrantReadWriteLock.LockType.SHARED, locker.getLockType());
+
+                if (lock instanceof FixedReentrantReadWriteLock.Lock) {
+                    final FixedReentrantReadWriteLock.Lock castLock =
+                            (FixedReentrantReadWriteLock.Lock) lock;
+                    castLock.setLendable(true);
+                }
+
+                try {
+                    Thread.sleep(300);
+                } catch (final InterruptedException ignored) {
+                }
+                return true;
+            }
+        });
+
+        // Give shared lock holder a moment
+        Thread.sleep(50);
+
+        // Thread 2: try to acquire exclusive lock (should borrow the shared lock)
+        final CompletableFuture<Boolean> exclusiveFuture = CompletableFuture.supplyAsync(() -> {
+            try (final FixedReentrantReadWriteLock.ILock lock = locker.exclusiveLock()) {
+                // While exclusive is held, lock count should decrease because shared was borrowed
+                assertEquals(1, locker.getLockCount());
+                assertEquals(FixedReentrantReadWriteLock.LockType.EXCLUSIVE, locker.getLockType());
+                return true;
+            }
+        });
+
+        assertTrue(exclusiveFuture.get(1, TimeUnit.SECONDS));
+        assertTrue(sharedFuture.get(1, TimeUnit.SECONDS));
+        assertEquals(0, locker.getLockCount());
+    }
+
+    @Test
+    public void lend_multiple_shared_locks_to_exclusive() throws Exception {
+        final FixedReentrantReadWriteLock locker = new FixedReentrantReadWriteLock();
+
+        // Thread 1: acquire first shared lock and set lendable
+        final CompletableFuture<Boolean> sharedFuture1 = CompletableFuture.supplyAsync(() -> {
+            try (final FixedReentrantReadWriteLock.ILock lock = locker.sharedLock()) {
+                if (lock instanceof FixedReentrantReadWriteLock.Lock) {
+                    final FixedReentrantReadWriteLock.Lock castLock =
+                            (FixedReentrantReadWriteLock.Lock) lock;
+                    castLock.setLendable(true);
+                }
+
+                try {
+                    Thread.sleep(300);
+                } catch (final InterruptedException ignored) {
+                }
+                return true;
+            }
+        });
+
+        Thread.sleep(50);
+
+        // Thread 2: acquire second shared lock and set lendable
+        final CompletableFuture<Boolean> sharedFuture2 = CompletableFuture.supplyAsync(() -> {
+            try (final FixedReentrantReadWriteLock.ILock lock = locker.sharedLock()) {
+                if (lock instanceof FixedReentrantReadWriteLock.Lock) {
+                    final FixedReentrantReadWriteLock.Lock castLock =
+                            (FixedReentrantReadWriteLock.Lock) lock;
+                    castLock.setLendable(true);
+                }
+
+                try {
+                    Thread.sleep(300);
+                } catch (final InterruptedException ignored) {
+                }
+                return true;
+            }
+        });
+
+        Thread.sleep(50);
+
+        // Both shared locks should now be held
+        assertEquals(2, locker.getLockCount());
+
+        // Thread 3: acquire exclusive lock (should borrow both shared locks)
+        final CompletableFuture<Boolean> exclusiveFuture = CompletableFuture.supplyAsync(() -> {
+            try (final FixedReentrantReadWriteLock.ILock lock = locker.exclusiveLock()) {
+                // Lock count should be 1 (only the exclusive lock)
+                assertEquals(1, locker.getLockCount());
+                assertEquals(FixedReentrantReadWriteLock.LockType.EXCLUSIVE, locker.getLockType());
+                return true;
+            }
+        });
+
+        assertTrue(exclusiveFuture.get(1, TimeUnit.SECONDS));
+        assertTrue(sharedFuture1.get(1, TimeUnit.SECONDS));
+        assertTrue(sharedFuture2.get(1, TimeUnit.SECONDS));
+        assertEquals(0, locker.getLockCount());
+    }
+
+    @Test
+    public void lend_single_shared_with_mix_lendable_and_non_lendable() throws Exception {
+        final FixedReentrantReadWriteLock locker = new FixedReentrantReadWriteLock();
+
+        // Thread 1: acquire non-lendable shared lock
+        final CompletableFuture<Boolean> nonLendableFuture = CompletableFuture.supplyAsync(() -> {
+            try (final FixedReentrantReadWriteLock.ILock lock = locker.sharedLock()) {
+                // This lock is non-lendable by default
+                try {
+                    Thread.sleep(200);
+                } catch (final InterruptedException ignored) {
+                }
+                return true;
+            }
+        });
+
+        Thread.sleep(50);
+
+        // Thread 2: try to acquire exclusive lock (should block because non-lendable shared exists)
+        final CompletableFuture<Boolean> exclusiveFuture = CompletableFuture.supplyAsync(() -> {
+            try (final FixedReentrantReadWriteLock.ILock lock = locker.exclusiveLock()) {
+                assertEquals(1, locker.getLockCount());
+                assertEquals(FixedReentrantReadWriteLock.LockType.EXCLUSIVE, locker.getLockType());
+                return true;
+            }
+        });
+
+        // Exclusive should be blocked initially
+        try {
+            exclusiveFuture.get(100, TimeUnit.MILLISECONDS);
+            fail("exclusive should have been blocked by non-lendable shared lock");
+        } catch (final Exception ignored) {
+            // expected
+        }
+
+        // After non-lendable shared is released, exclusive should proceed
+        assertTrue(nonLendableFuture.get(1, TimeUnit.SECONDS));
+        assertTrue(exclusiveFuture.get(1, TimeUnit.SECONDS));
+        assertEquals(0, locker.getLockCount());
+    }
+
+    @Test
+    public void lent_locks_are_restored_after_exclusive_release() throws Exception {
+        final FixedReentrantReadWriteLock locker = new FixedReentrantReadWriteLock();
+
+        final java.util.concurrent.atomic.AtomicInteger lockCountAfterExclusiveRelease =
+                new java.util.concurrent.atomic.AtomicInteger(-1);
+
+        // Thread 1: acquire shared lock and set lendable
+        final CompletableFuture<Boolean> sharedFuture = CompletableFuture.supplyAsync(() -> {
+            try (final FixedReentrantReadWriteLock.ILock lock = locker.sharedLock()) {
+                if (lock instanceof FixedReentrantReadWriteLock.Lock) {
+                    final FixedReentrantReadWriteLock.Lock castLock =
+                            (FixedReentrantReadWriteLock.Lock) lock;
+                    castLock.setLendable(true);
+                }
+
+                try {
+                    Thread.sleep(150);
+                } catch (final InterruptedException ignored) {
+                }
+
+                // Check lock count after exclusive is released
+                lockCountAfterExclusiveRelease.set(locker.getLockCount());
+                return true;
+            }
+        });
+
+        Thread.sleep(50);
+
+        // Thread 2: acquire exclusive lock (should borrow the shared lock)
+        final CompletableFuture<Boolean> exclusiveFuture = CompletableFuture.supplyAsync(() -> {
+            try (final FixedReentrantReadWriteLock.ILock lock = locker.exclusiveLock()) {
+                assertEquals(1, locker.getLockCount());
+                return true;
+            }
+        });
+
+        assertTrue(exclusiveFuture.get(1, TimeUnit.SECONDS));
+        assertTrue(sharedFuture.get(1, TimeUnit.SECONDS));
+
+        // The lock count after exclusive release should be 1 again (shared lock restored)
+        assertEquals(1, lockCountAfterExclusiveRelease.get());
+        assertEquals(0, locker.getLockCount());
+    }
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to contribute 🙌 -->
<!-- Pull request titles must be in English. -->

#### What kind of changes does this PR include?

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Minor content fixes (broken links, typos, exceptions, etc.)
- [ ] New or updated content
- [ ] Documentation updates
- [ ] Assets content
- [ ] Code refactoring
- [ ] Dependency updates
- [ ] Runtime updates
- [ ] Build Logic updates
- [ ] Other

---

#### Description

<!--
Did you make any visual changes? If so, a screenshot or video would be helpful.
-->

- Implemented functionality for lending shared locks to exclusive locks when applicable.
- Updated unlock logic to restore lent locks after exclusive lock release.
- Enhanced test coverage with multiple scenarios for lock lending. Bumped version to 5.1.0.<!-- Please provide a brief summary of the changes introduced by this PR. -->

---

## Does this PR introduce a breaking change?

<!--
We prefer to avoid breaking changes.
We will only accept PRs with breaking changes if they have been discussed in an issue first.

Please check one of the boxes below to indicate if this PR introduces a breaking change.
-->

- [ ] Yes
- [ ] No

---

## Additional Notes

- <!-- If there's anything else you want to add, mention it here. -->

---

## Related Issue or PR

- <!-- Add an issue or PR number if this PR is related to one. -->

<!--
If you are suggesting a new feature or change, please discuss it in an issue first.
If you are fixing a bug, there should be an issue describing it using a bug report template.
-->

---

<!--
Please keep your changes minimal and focused.
Pull requests with redundant code may be rejected.

If you create new classes or methods, adding documentation is appreciated.
-->
